### PR TITLE
Update a Russian translation

### DIFF
--- a/ru_RU.lang
+++ b/ru_RU.lang
@@ -11,7 +11,7 @@ replaymod.chat.failedthumb=Невозможно сохранить миниат�
 replaymod.chat.addedmarker=Маркер события добавлен
 
 #Chat messages displayed in Replay Viewer
-replaymod.chat.morekeyframes=Требуется как минимум 2 ключевых кадра позиции и 2 ключевых кадра времени
+replaymod.chat.morekeyframes=Требуется не менее двух ключевых кадров позиции и двух кадров времени
 replaymod.chat.pathstarted=Воспроизведение дорожки начато
 replaymod.chat.pathfinished=Воспроизведение дорожки завершено
 replaymod.chat.pathinterrupted=Воспроизведение дорожки остановлено
@@ -21,17 +21,17 @@ replaymod.gui.cancel=Отмена
 replaymod.gui.back=Назад
 replaymod.gui.load=Загрузить
 replaymod.gui.save=Сохранить
-replaymod.gui.rename=Переименовать
+replaymod.gui.rename=Назвать
 replaymod.gui.remove=Удалить
 replaymod.gui.delete=Удалить
 replaymod.gui.recording=Запись
 replaymod.gui.paused=Пауза
 replaymod.gui.speed=Скорость
 replaymod.gui.pleasewait=Подождите
-replaymod.gui.render=Рендер
+replaymod.gui.render=Отрендерить
 replaymod.gui.iphidden=Адрес сервера скрыт
 replaymod.gui.overwrite=Перезаписать
-replaymod.gui.saveas=Сохранить как...
+replaymod.gui.saveas=Сохранить...
 replaymod.gui.done=Готово
 replaymod.gui.close=Закрыть
 replaymod.gui.notagain=Больше не показывать
@@ -39,12 +39,12 @@ replaymod.gui.edit=Изменить
 replaymod.gui.copy=Копировать
 replaymod.gui.paste=Вставить
 
-replaymod.gui.recording.resume=⏯ Запись
-replaymod.gui.recording.pause=⏸Запись
-replaymod.gui.recording.stop=■ Запись
-replaymod.gui.recording.start=▶ Запись
+replaymod.gui.recording.resume=Возобновить
+replaymod.gui.recording.pause=Приостановить
+replaymod.gui.recording.stop=Завершить запись
+replaymod.gui.recording.start=Начать запись
 
-replaymod.gui.renderdonetitle=Визуализация завершена
+replaymod.gui.renderdonetitle=Рендеринг завершён
 replaymod.gui.openfolder=Открыть папку с видео
 replaymod.gui.youtubeupload=Загрузить на YouTube
 replaymod.gui.renderdone1=Видео отрендерено.
@@ -61,7 +61,7 @@ replaymod.gui.ytuploadprogress.prepare_video=[1/4] Подготовка виде
 replaymod.gui.ytuploadprogress.upload=[3/4] Загрузка: %%d%%%%
 replaymod.gui.ytuploadprogress.cleanup=[4/4] Очистка
 replaymod.gui.ytuploadprogress.done=Готово: %s
-replaymod.gui.titleempty=Название не может быть пустым
+replaymod.gui.titleempty=Нет названия
 replaymod.gui.videothumbnailtoolarge=Размер изображения превышает 2 Мбайт
 replaymod.gui.videothumbnailformat=Изображение должно быть в формате JPEG или PNG
 
@@ -83,7 +83,7 @@ replaymod.gui.exit=Покинуть повтор
 
 replaymod.gui.settings=Настройки
 
-replaymod.gui.keyframerepo.delete=Вы уверены, что хотите удалить данные ключевые кадры?
+replaymod.gui.keyframerepo.delete=Вы уверены, что хотите удалить выбранные ключевые кадры?
 replaymod.gui.keyframerepo.overwrite=Вы уверены, что хотите перезаписать данные ключевые кадры?
 
 replaymod.gui.restorereplay1=Похоже, Minecraft был закрыт необычным образом.
@@ -94,7 +94,7 @@ replaymod.gui.loadentitytracker=Загрузка местоположения с
 replaymod.gui.loadquickmode=Загрузка быстрого режима: %%d%%%%
 replaymod.gui.noquickmode=Быстрый режим доступен только в Minecraft %1$s и выше
 replaymod.gui.minimalmode.unsupported=Эта функция недоступна в текущей версии Minecraft.
-replaymod.gui.minimalmode.supportedversion=(только Minecraft %1$s поддерживается вашей версией Replay Mod)
+replaymod.gui.minimalmode.supportedversion=(текущая версия Replay Mod поддерживает только Minecraft %1$s)
 
 #Only change these if it's neccessary
 replaymod.gui.replayviewer=Просмотрщик повторов
@@ -102,7 +102,7 @@ replaymod.gui.replayviewer=Просмотрщик повторов
 #Replay Viewer GUI
 replaymod.gui.viewer.rename.name=Название повтора
 replaymod.gui.viewer.replayfolder=Папка повторов...
-replaymod.gui.viewer.bulkrender=Рендер %1$d видео
+replaymod.gui.viewer.bulkrender=Отрендерить %1$d видео
 
 replaymod.gui.viewer.delete.linea=Вы уверены, что хотите удалить этот повтор?
 replaymod.gui.viewer.delete.failed1=ОС не дала возможность переместить повтор.
@@ -118,13 +118,13 @@ replaymod.gui.edit.cut.end=Конец отреза
 replaymod.gui.edit.cut.tooltip=Удаляет отрезок из повтора
 
 #Cancel Replay GUI
-replaymod.gui.cancelrender.title=Остановка визуализации
-replaymod.gui.cancelrender.message=Вы уверены, что хотите прекратить текущий процесс визуализации?
+replaymod.gui.cancelrender.title=Прекращение рендеринга
+replaymod.gui.cancelrender.message=Вы уверены, что хотите прекратить текущий процесс рендеринга?
 #Saving Replay GUI
 replaymod.gui.replaysaving.title=Сохранение файла повтора...
 
 #Player Overview GUI
-replaymod.gui.playeroverview.visible=Видимый
+replaymod.gui.playeroverview.visible=Видимость
 replaymod.gui.playeroverview.hideall=Скрыть всех
 replaymod.gui.playeroverview.showall=Показать всех
 replaymod.gui.playeroverview.spectate=Наблюдать за...
@@ -139,43 +139,43 @@ replaymod.gui.settings.notifications=Уведомления
 replaymod.gui.settings.recordserver=Запись сервера
 replaymod.gui.settings.recordsingleplayer=Запись одиночной игры
 replaymod.gui.settings.indicator=Индикатор записи
-replaymod.gui.settings.pathpreview=Дорожка камеры
+replaymod.gui.settings.pathpreview=Отображение дорожки
 replaymod.gui.settings.camera=Камера
 replaymod.gui.settings.showchat=Чат
 replaymod.gui.settings.interpolator=Интерполяция
-replaymod.gui.settings.autostartrecording=Авто-Запись
-replaymod.gui.settings.rename_recording_dialog=Переимен. Диалог
+replaymod.gui.settings.autostartrecording=Автозапись
+replaymod.gui.settings.rename_recording_dialog=Диалог сохранения
 replaymod.gui.settings.fullbrightness=Полная яркость
 replaymod.gui.settings.fullbrightness.gamma=Гамма
-replaymod.gui.settings.fullbrightness.nightvision=Ночное зрение
+replaymod.gui.settings.fullbrightness.nightvision=Эффект
 replaymod.gui.settings.fullbrightness.both=Оба
 
 #Replay Mod Keybindings
-replaymod.input.lighting=Ночное видение
+replaymod.input.lighting=Полная яркость
 replaymod.input.thumbnail=Сделать миниатюру
 replaymod.input.playeroverview=Список игроков
 replaymod.input.clearkeyframes=Удалить ключевые кадры
 replaymod.input.synctimeline=Синхронизировать временную шкалу
-replaymod.input.keyframerepository=Сохранения ключевых кадров
+replaymod.input.keyframerepository=Наборы ключевых кадров
 replaymod.input.rollclockwise=Наклон камеры: вправо
 replaymod.input.rollcounterclockwise=Наклон камеры: влево
 replaymod.input.resettilt=Наклон камеры: сброс
-replaymod.input.playpause=Воспроизведение/Пауза
+replaymod.input.playpause=Воспроизвести или приостановить
 replaymod.input.marker=Добавить маркер события
 replaymod.input.pathpreview=Отображение дорожки
 replaymod.input.settings=Настройки ReplayMod
 replaymod.input.quickmode=Быстрый режим
-replaymod.input.positionkeyframe=Ключевой кадр Позиции/Наблюдателя
-replaymod.input.positiononlykeyframe=Ключевой кадр позиции
+replaymod.input.positionkeyframe=Ключевой кадр позиции
+replaymod.input.positiononlykeyframe=Ключевой кадр позиции вне наблюдения
 replaymod.input.timekeyframe=Ключевой кадр времени
 replaymod.input.bothkeyframes=Ключевой кадр позиции + времени
 
 # CameraControllers
-replaymod.camera.classic=Классическая
-replaymod.camera.vanilla=Стандартная
+replaymod.camera.classic=Replay Mod
+replaymod.camera.vanilla=Minecraft
 
 #Keyframe Presets GUI
-replaymod.gui.keyframerepository.title=Сохранения ключевых кадров
+replaymod.gui.keyframerepository.title=Наборы ключевых кадров
 
 #Edit Keyframe GUI
 replaymod.gui.editkeyframe.title.pos=Ключевой кадр позиции
@@ -190,28 +190,29 @@ replaymod.gui.editkeyframe.camyaw=Рысканье
 replaymod.gui.editkeyframe.camroll=Крен
 replaymod.gui.editkeyframe.timelineposition=Временная шкала
 replaymod.gui.editkeyframe.markername=Название
-replaymod.gui.editkeyframe.timestamp=Индекс времени
+replaymod.gui.editkeyframe.timestamp=Отметка времени
 
 replaymod.gui.editkeyframe.interpolator=Интерполяция
 replaymod.gui.editkeyframe.interpolator.default.name=По умолчанию
-replaymod.gui.editkeyframe.interpolator.default.desc=Интерполяция по умолчанию, выбранная в настройках.
-replaymod.gui.editkeyframe.interpolator.catmullrom.name=Эрмитов сплайн
-replaymod.gui.editkeyframe.interpolator.catmullrom.desc=Кубический сплайн Эрмита с изменяемым значением для точной калибровки и плавности дорожки камеры.
-replaymod.gui.editkeyframe.interpolator.catmullrom.alpha=Значение:
-replaymod.gui.editkeyframe.interpolator.cubic.name=Кубический сплайн
-replaymod.gui.editkeyframe.interpolator.cubic.desc=Матрица кубического уравнения всех точек для плавности дорожки камеры.
+replaymod.gui.editkeyframe.interpolator.default.desc=Интерполяция по умолчанию, выбранная в настройках мода.
+replaymod.gui.editkeyframe.interpolator.catmullrom.name=Катмулла — Рома
+replaymod.gui.editkeyframe.interpolator.catmullrom.desc=Сплайн Катмулла — Рома с изменяемым значением для точной калибровки плавности дорожки камеры.
+replaymod.gui.editkeyframe.interpolator.catmullrom.alpha=Плавность:
+replaymod.gui.editkeyframe.interpolator.cubic.name=Кубическая
+replaymod.gui.editkeyframe.interpolator.cubic.desc=Кубический сплайн всех точек, создающий плавность дорожки камеры.
 replaymod.gui.editkeyframe.interpolator.linear.name=Линейная
 replaymod.gui.editkeyframe.interpolator.linear.desc=Прямые линии между ключевыми кадрами.
 
 #Render Settings GUI
-replaymod.gui.rendersettings.addtoqueue=Добавить в очередь
+replaymod.gui.rendersettings.addtoqueue=В очередь
 
-replaymod.gui.rendersettings.renderer=Метод Рендера
+replaymod.gui.rendersettings.renderer=Рендеринг
 
 replaymod.gui.rendersettings.renderer.default=Стандартный
-replaymod.gui.rendersettings.renderer.stereoscopic=Стереоскопическая
+replaymod.gui.rendersettings.renderer.tiled=Плиточный
+replaymod.gui.rendersettings.renderer.stereoscopic=Стереоскопический
 replaymod.gui.rendersettings.renderer.cubic=Кубический
-replaymod.gui.rendersettings.renderer.equirectangular=Равнопромежуточная
+replaymod.gui.rendersettings.renderer.equirectangular=Равнопромежуточный
 replaymod.gui.rendersettings.renderer.ods=ODS
 replaymod.gui.rendersettings.renderer.blend=Экспорт в Blender [Экспериментально]
 
@@ -222,8 +223,8 @@ replaymod.gui.rendersettings.renderer.equirectangular.description=Видео с 
 replaymod.gui.rendersettings.renderer.ods.description=Видео со стереоскопическим 360-градусным панорамным видом, также известное как VR-видео. Его можно воспроизвести в YouTube.
 replaymod.gui.rendersettings.renderer.blend.description=Видимые контуры, экспортированные в .blend-файл, который можно открыть в Blender. Крайне нестабильная функция! Требуется большой объём памяти, содержит довольно много ошибок, иногда генерирует повреждённые файлы.
 
-replaymod.gui.rendersettings.customresolution=Разрешение видео
-replaymod.gui.rendersettings.customresolution.warning.yuv420=Длина и ширина должны быть чётными числами.
+replaymod.gui.rendersettings.customresolution=Разрешение
+replaymod.gui.rendersettings.customresolution.warning.yuv420=Длина и ширина должны быть чётными числами
 replaymod.gui.rendersettings.customresolution.warning.yuv420.cubic=Высота должна быть кратна 6
 replaymod.gui.rendersettings.customresolution.warning.cubic.height=При кубическом рендеринге высота должна быть кратна 3
 replaymod.gui.rendersettings.bitrate=Битрейт
@@ -252,12 +253,12 @@ replaymod.gui.rendersettings.commandline=Параметры командной �
 replaymod.gui.rendersettings.presets=Кодирование
 replaymod.gui.rendersettings.presets.mp4.custom=MP4 — Свой битрейт
 replaymod.gui.rendersettings.presets.mp4.default=MP4 — Обычное качество
-replaymod.gui.rendersettings.presets.mp4.potato=MP4 — Картофельное качество
+replaymod.gui.rendersettings.presets.mp4.potato=MP4 — Шакалистое качество
 replaymod.gui.rendersettings.presets.webm.custom=WEBM — Свой битрейт
 replaymod.gui.rendersettings.presets.mkv.lossless=MKV — Без потерь
-replaymod.gui.rendersettings.presets.blend=Blend файл
-replaymod.gui.rendersettings.presets.png=PNG-файлы
-replaymod.gui.rendersettings.presets.exr=OpenEXR-файлы
+replaymod.gui.rendersettings.presets.blend=.blend-файл
+replaymod.gui.rendersettings.presets.png=Серия PNG-файлов
+replaymod.gui.rendersettings.presets.exr=Серия OpenEXR-файлов
 
 replaymod.gui.rendersettings.antialiasing=Сглаживание
 replaymod.gui.rendersettings.antialiasing.none=Нет
@@ -266,13 +267,13 @@ replaymod.gui.rendersettings.antialiasing.x4=4x
 replaymod.gui.rendersettings.antialiasing.x8=8x
 
 #Render Queue GUI
-replaymod.gui.renderqueue.title=Очередь рендера
-replaymod.gui.renderqueue.add=Добавить текущую конфигурацию
-replaymod.gui.renderqueue.renderall=Рендерить все
-replaymod.gui.renderqueue.renderselected=Рендер выбран
+replaymod.gui.renderqueue.title=Очередь рендеринга
+replaymod.gui.renderqueue.add=Добавить текущую дорожку
+replaymod.gui.renderqueue.renderall=Отрендерить всё
+replaymod.gui.renderqueue.renderselected=Отрендерить выбранное
 
 #Rendering GUI
-replaymod.gui.rendering.title=Рендер видео
+replaymod.gui.rendering.title=Рендеринг
 replaymod.gui.rendering.pause=Приостановить
 replaymod.gui.rendering.resume=Возобновить
 replaymod.gui.rendering.cancel=Отмена
@@ -283,7 +284,7 @@ replaymod.gui.rendering.timetaken=Время
 replaymod.gui.rendering.timeleft=Осталось времени
 
 #Render Errors
-replaymod.gui.rendering.error.title=Ошибка рендера
+replaymod.gui.rendering.error.title=Ошибка рендеринга
 replaymod.gui.rendering.error.message=Чтобы отрендерить видео, необходимо установить ffmpeg.
 replaymod.gui.rendering.error.ffmpeglog=Вывод FFmpeg:
 replaymod.gui.rendering.error.ffmpegargs.1=Похоже, аргументы командной строки были изменены.
@@ -298,7 +299,7 @@ replaymod.gui.ingame.menu.addtimekeyframe=Новый ключевой кадр �
 replaymod.gui.ingame.menu.removetimekeyframe=Удалить ключевой кадр времени
 replaymod.gui.ingame.menu.pause=Приостановить повтор
 replaymod.gui.ingame.menu.unpause=Возобновить повтор
-replaymod.gui.ingame.menu.renderpath=Визуализировать
+replaymod.gui.ingame.menu.renderpath=Отрендерить
 replaymod.gui.ingame.menu.playpath=Воспроизвести дорожку
 replaymod.gui.ingame.menu.playpathfromstart=Воспроизвести дорожку с начала
 replaymod.gui.ingame.menu.pausepath=Приостановить дорожку
@@ -315,7 +316,7 @@ replaymod.gui.ingame.first_keyframe_not_at_start_warning=Заданный пер
 replaymod.gui.clearcallback.title=Удалить все ключевые кадры?
 
 #Errors
-replaymod.error.unknownrestriction1=Повтор невозможно воспроизвести на данной версии.
+replaymod.error.unknownrestriction1=Повтор невозможно воспроизвести на текущей версии.
 replaymod.error.unknownrestriction2=Была попытка запустить неизвестную версию %s.
 replaymod.error.negativetime1=Ключевые кадры времени расставлены не по порядку.
 replaymod.error.negativetime2=Переход назад во времени не поддерживается.
@@ -324,14 +325,14 @@ replaymod.error.negativetime3=Недействительные части пом
 #Replay Mod Incompatibility Warning
 replaymod.gui.modwarning.title=Обнаружена несовместимость
 replaymod.gui.modwarning.message1=Обнаружена возможная несовместимость между
-replaymod.gui.modwarning.message2=текущей версией Minecraft и и данным повтором.
-replaymod.gui.modwarning.message3=Открытие данного повтора может привести к ошибкам или сбою работы.
-replaymod.gui.modwarning.name=Название модификации:
-replaymod.gui.modwarning.id=ID модификации:
-replaymod.gui.modwarning.missing=Недостающие модификации
+replaymod.gui.modwarning.message2=текущей версией Minecraft и выбранным повтором.
+replaymod.gui.modwarning.message3=Открытие повтора может привести к ошибкам или сбою.
+replaymod.gui.modwarning.name=Название:
+replaymod.gui.modwarning.id=ID:
+replaymod.gui.modwarning.missing=Недостающие моды
 replaymod.gui.modwarning.version=Различие версий
-replaymod.gui.modwarning.version.expected=Ожидалась
-replaymod.gui.modwarning.version.found=Найдена
+replaymod.gui.modwarning.version.expected=Ожидаемая версия
+replaymod.gui.modwarning.version.found=Найденная версия
 
 #Advanced Screenshots Gui
 replaymod.gui.advancedscreenshots.title=Настройки скриншота
@@ -341,6 +342,6 @@ replaymod.gui.advancedscreenshots.resolution=Разрешение
 # Screenshot Finished Gui
 replaymod.gui.advancedscreenshots.finished.description=Скриншот создан!
 replaymod.gui.advancedscreenshots.finished.description.360=Скриншот с углом обзора в 360° создан!
-replaymod.gui.advancedscreenshots.finished.description.veer=Загрузите и просмотрите изображение в VR на VeeR.tv или откройте его на диске.
+replaymod.gui.advancedscreenshots.finished.description.veer=Загрузите и посмотрите его в VR на VeeR.tv или откройте папку с файлом.
 replaymod.gui.advancedscreenshots.finished.upload.veer=Загрузить на VeeR.tv
-replaymod.gui.advancedscreenshots.finished.showfile=Открыть файл
+replaymod.gui.advancedscreenshots.finished.showfile=Показать в папке


### PR DESCRIPTION
Let me explain why my PR should be merged and not any other using the differences from [the `d.diff` file](https://github.com/ReplayMod/Translations/pull/15#issuecomment-1186605990). 

`replaymod.chat.morekeyframes`[^note]
In my opinion, "не менее" is just better. "2" should be replaced with a word (otherwise, it would be read as "два" instead of "двух"). 

`replaymod.gui.rename`[^note]
Only my translation fits into the related button.

`replaymod.gui.render`
"Отрендерить" is a verb. That's better for buttons.

`replaymod.gui.saveas`
Only my translation fits into the related button.

`replaymod.gui.renderdonetitle`[^note]
"Рендеринг" is a process. It's not right to use "рендер" here.

`replaymod.gui.recording.resume`
`replaymod.gui.recording.pause`
`replaymod.gui.recording.stop`
`replaymod.gui.recording.start`
Using icons in texts is just bad. I translated them without icons and they still fit into buttons.

`replaymod.gui.titleempty`
My translation is pithy and shorter which is better for UI texts.

`replaymod.gui.keyframerepo.delete`[^note]
"Данные" (these) is mostly used in formal and scientific contexts. It could be replaced with "эти", but I prefered to use "выбранные" ("chosen") to clarify what are "these" keyframes.

`replaymod.gui.minimalmode.supportedversion`[^note]
Rearranged text and made it easier to read.

`replaymod.gui.viewer.bulkrender`
"Отрендерить" is a verb. That's better for buttons.

`replaymod.gui.viewer.delete.lineb`
I'm not sure why I replaced `%1$s` with `%s`. No actions required.

`replaymod.gui.cancelrender.title`[^note]
`replaymod.gui.cancelrender.message`[^note]
"Render"-related strings changed their translations from "визуализация" to "редеринг", so it should be changed everywhere including this string.

`replaymod.gui.playeroverview.visible`[^note]
I use a noun here. That makes it more neutral.

`replaymod.gui.settings.pathpreview`[^note]
I think it's better to translate this option as "Show Path Preview" from `replaymod.input.pathpreview` instead of "Camera Path Preview".

`replaymod.gui.settings.autostartrecording`
My translation is a grammatically correct version of others.

`replaymod.gui.settings.rename_recording_dialog`
Using shorten words with "." is just bad. Most importantly, the merged string translated as "rename a dialog" instead of "dialog of renaming" or similar!

`replaymod.gui.settings.fullbrightness.nightvision`[^note]
I made it fit a drop-down list.

`replaymod.input.lighting`[^note]
I prefer "Full Brightness" from `replaymod.gui.settings.fullbrightness`, not the currently merged "Night Vision".

`replaymod.input.keyframerepository`[^note]
I think "наборы" (sets) instead of "сохранения" (saves) is a better word for that.

`replaymod.input.playpause`[^note]
The merged translation has a bad line wrapping in the game UI.

`replaymod.input.positionkeyframe`
A direct translation of `.bothkeyframes` would be too long ("Ключевой кадр позиции/наблюдения + времени"), so I decided to replace "position/spectator" with "position". So I had to change that in this `.positionkeyframe` translation. 

`replaymod.input.positiononlykeyframe`
I can't use just "position" because the translation would be the same as in the previous string. So I translated it as "a keyframe of position outside spectating".

`replaymod.camera.classic`
`replaymod.camera.vanilla`
I just don't like how it's called and I don't like the "vanilla" word. I decided to make it more clear using "Replay Mod" and "Minecraft" as translations.

`replaymod.gui.keyframerepository.title`[^note]
Same as `replaymod.input.keyframerepository`.

`replaymod.gui.editkeyframe.timestamp`
"Отметка времени" (timestamp) is more clear then "индекс" (index).

`replaymod.gui.editkeyframe.interpolator.default.desc`[^note]
Replaced "options" with "mod options" making this translation more clear.

`replaymod.gui.editkeyframe.interpolator.catmullrom.name`[^note]
`replaymod.gui.editkeyframe.interpolator.catmullrom.desc`[^note]
Fixed the translation by replacing "Hermite Spline" with "Catmull Rom" one.

`replaymod.gui.editkeyframe.interpolator.catmullrom.alpha`[^note]
Translated it as "Smoothness" (instead of "Value") to make it more intuitive.

`replaymod.gui.editkeyframe.interpolator.cubic.name`[^note]
Made it shorter to fit into the drop-down list in keyframe options.

`replaymod.gui.rendersettings.addtoqueue`[^note]
Only my translation fits into the related button.

`replaymod.gui.rendersettings.renderer`
The merged translation uses wrong terminology and doesn't follow case rules. In addition, we can shorten it to a single word.

`replaymod.gui.rendersettings.renderer.stereoscopic`[^note]
`replaymod.gui.rendersettings.renderer.equirectangular`[^note]
The changed translation of "render" also requires to change a grammatical gender of related translations from feminine to masculine.

`replaymod.gui.rendersettings.customresolution`[^note]
Shorten it to a single word.

`replaymod.gui.rendersettings.customresolution.warning.yuv420`[^note]
Removed "." because it doesn't exist in the original string.

`replaymod.gui.rendersettings.presets.mp4.potato`[^note]
"Potato Quality" is an English internet slang. I translated it as a Russian internet slang.

`replaymod.gui.rendersettings.presets.blend`
My translation is a grammatically correct version of others and it's more common.

`replaymod.gui.rendersettings.presets.png`
`replaymod.gui.rendersettings.presets.exr`
I decided to include a "sequence" in my translation. That looks better.

`replaymod.gui.renderqueue.title`
"Рендер" is not a correct word here, "рендеринг" should be used instead. I suggested "очередь" (Queue) in my PR, but now I think we can use "Очередь рендеринга" (Render Queue) instead, so it would be more intuitive for a user.

`replaymod.gui.renderqueue.renderall`
"Отрендерить" is a verb. That's better for buttons.

`replaymod.gui.renderqueue.renderselected`
"Отрендерить" is a verb. That's better for buttons. Also, the merged string was translated as "render is selected" instead of "render selected [elements]"!

`replaymod.gui.rendering.error.title`
"Рендер" is not a correct word here, "рендеринг" should be used instead.

`replaymod.gui.ingame.menu.renderpath`[^note]
The merged translation uses an old "визализация"-related word instead of "рендер"-related. I suggested "Отрендерить" (Render) because it's actually a single option to render on the screen, but we may use "Отрендерить дорожку" (Render Camera Path) here if you want to.

`replaymod.error.unknownrestriction1`[^note]
"Данной" (this) is mostly used in formal and scientific contexts. I replaced it with "текущей" (current)

`replaymod.gui.modwarning.message2`[^note]
"Данным" (these) is mostly used in formal and scientific contexts. I replaced it with "выбранным" (chosen). Also, the merged translation contains "и" (and) twice.

`replaymod.gui.modwarning.message3`[^note]
Made it shorter.

<a name="replaymod.gui.modwarning.name">`replaymod.gui.modwarning.name`[^note]</a>
`replaymod.gui.modwarning.id`[^note]
Removed "mod" because that's obvious from context, and I don't want it being repetitious.

`replaymod.gui.modwarning.missing`[^note]
Used more shorter translation of "mods" ("моды" instead of "модификации") which is more common in modding-related translations.

`replaymod.gui.modwarning.version.expected`[^note]
`replaymod.gui.modwarning.version.found`[^note]
That's opposite to [`replaymod.gui.modwarning.(name|id)`](#replaymod.gui.modwarning.name). `replaymod.gui.modwarning.version` isn't used for missing mods, so I added "версия" ("version") here.

`replaymod.gui.advancedscreenshots.finished.description.veer`[^note]
Used "его" (it) instead of "изображение" (the image) because it's obvious from the title string and that makes the string shorter which is a good thing here. Also, fixed a factual error by replacing "open the image" with "open a folder with the file".

`replaymod.gui.advancedscreenshots.finished.showfile`[^note]
Fixed a factual error by replacing "open the file" with "show in a folder".

[^note]: A merged translation wasn't suggested by none of PRs, it was actually added by me 5+ years ago. So why a new string from a new me wasn't merged? :)
